### PR TITLE
Improve tool verification exit handling

### DIFF
--- a/SystemTester.bat
+++ b/SystemTester.bat
@@ -241,13 +241,16 @@ echo.
 pause
 echo.
 :: Call the PowerShell function for tool verification
-powershell -NoProfile -ExecutionPolicy Bypass -Command "try { . '%SCRIPT_PS1%'; Test-ToolVerification; exit 0 } catch { Write-Error $_; exit 1 }"
-if errorlevel 1 (
-    echo.
-    echo [ERROR] Verification encountered an issue. Review output above.
+powershell -NoProfile -ExecutionPolicy Bypass -Command "try { . ""%SCRIPT_PS1%""; if (-not (Test-ToolVerification)) { exit 2 } else { exit 0 } } catch { Write-Error $_; exit 1 }"
+set "VERIFY_CODE=%errorlevel%"
+echo.
+if "%VERIFY_CODE%"=="0" (
+    echo Verification complete. All tools validated successfully.
+) else if "%VERIFY_CODE%"=="2" (
+    echo [WARNING] Verification completed with issues detected. Review output above.
+    echo         Use Menu Option 5 to re-download the Sysinternals Suite.
 ) else (
-    echo.
-    echo Verification complete.
+    echo [ERROR] Verification encountered an issue. Review output above.
 )
 echo.
 pause

--- a/SystemTester.ps1
+++ b/SystemTester.ps1
@@ -119,6 +119,9 @@ function Test-ToolVerification {
     
     foreach ($tool in $allTools) {
         $result = Test-ToolIntegrity -ToolName $tool
+        if (-not $stats.ContainsKey($result.Status)) {
+            $stats[$result.Status] = 0
+        }
         $stats[$result.Status]++
         
         $color = switch ($result.Status) {
@@ -160,15 +163,28 @@ function Test-ToolVerification {
     Write-Host ""
     
     $totalIssues = $stats.BAD_SIZE + $stats.BAD_SIGNATURE + $stats.MISSING + $stats.CHECK_FAILED
-    if ($totalIssues -eq 0 -and $stats.VALID_MS -gt 0) {
+    if ($totalIssues -eq 0 -and ($stats.VALID_MS + $stats.VALID_OTHER + $stats.NOT_SIGNED) -gt 0) {
         Write-Host "STATUS: All present tools are verified and safe to use" -ForegroundColor Green
-    } elseif ($totalIssues -gt 0) {
+        Write-Host ""
+        return $true
+    }
+
+    if ($totalIssues -gt 0) {
         Write-Host "STATUS: $totalIssues issue(s) detected - recommend re-download" -ForegroundColor Yellow
         if ($script:LaunchedViaBatch) {
             Write-Host "ACTION: Use Batch Menu Option 5 to re-download tools" -ForegroundColor Yellow
         }
+        Write-Host ""
+        return $false
+    }
+
+    Write-Host "STATUS: No tools were successfully verified" -ForegroundColor Yellow
+    Write-Host "        Ensure Sysinternals Suite is installed" -ForegroundColor Yellow
+    if ($script:LaunchedViaBatch) {
+        Write-Host "ACTION: Use Batch Menu Option 5 to download tools" -ForegroundColor Yellow
     }
     Write-Host ""
+    return $false
 }
 
 # Initialize environment


### PR DESCRIPTION
## Summary
- teach the PowerShell Test-ToolVerification helper to return a success flag and cope with unexpected status codes
- propagate the verification result back to the batch launcher with distinct exit codes and clearer messaging for failures or warnings

## Testing
- not run (Windows-specific batch/PowerShell scripts)

------
https://chatgpt.com/codex/tasks/task_e_69050732fb1c8325ae986af05e8091bf