### PR TITLE
Fix host:port interpolation in network latency test

### DIFF
--- a/SystemTester.ps1
+++ b/SystemTester.ps1
@@ -588,7 +588,7 @@ function Test-NetworkLatency {
 
     $targetHost = "8.8.8.8"
     $targetPort = 443
-    $lines = @("Target: $targetHost:$targetPort")
+    $lines = @("Target: $($targetHost):$targetPort")
     $status = "SUCCESS"
 
     # Built-in Test-NetConnection results
@@ -611,7 +611,7 @@ function Test-NetworkLatency {
     try {
         $pspingPath = Join-Path $SysinternalsPath "psping.exe"
         if (Test-Path $pspingPath) {
-            $args = @("-accepteula", "-n", "5", "$targetHost:$targetPort")
+            $args = @("-accepteula", "-n", "5", "{0}:{1}" -f $targetHost, $targetPort)
             Write-Host "Running PsPing latency test..." -ForegroundColor Yellow
             $pspingOutput = & $pspingPath $args 2>&1 | Out-String
             $lines += "PsPing Summary:"


### PR DESCRIPTION
## Summary
- ensure host and port strings in the network latency test are constructed safely when strict mode is enabled
- format the PsPing argument using `-f` to avoid PowerShell parsing errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690508791e14832587fcb13d65040b88